### PR TITLE
Fixing missing hosts entry under the group dict

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -220,12 +220,13 @@ In YAML:
 .. code-block:: yaml
 
     atlanta:
-      host1:
-        http_port: 80
-        maxRequestsPerChild: 808
-      host2:
-        http_port: 303
-        maxRequestsPerChild: 909
+      hosts:    
+        host1:
+          http_port: 80
+          maxRequestsPerChild: 808
+        host2:
+          http_port: 303
+          maxRequestsPerChild: 909
 
 Unique values like non-standard SSH ports work well as host variables. You can add them to your Ansible inventory by adding the port number after the hostname with a colon:
 


### PR DESCRIPTION
The documentation is currently placing hosts directly under the group dictionary, but they should be under a `hosts` entry.